### PR TITLE
Using the newer ES6 arrow syntax

### DIFF
--- a/microbit/radio_receive.js
+++ b/microbit/radio_receive.js
@@ -1,4 +1,4 @@
 radio.setGroup(1)
-radio.onReceivedString(function (receivedString) {
+radio.onReceivedString(receivedString => {
     basic.showString(receivedString)
 })


### PR DESCRIPTION
Using the newer arrow syntax for defining anonymous functions in javascript ES6